### PR TITLE
Badge added to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/cerndb/dbod-web.svg?branch=master)](https://travis-ci.org/cerndb/dbod-web)
+[![Coverage Status](https://coveralls.io/repos/github/cerndb/dbod-web/badge.svg?branch=master)](https://coveralls.io/github/cerndb/dbod-web?branch=master)
 
 # Dbod
 


### PR DESCRIPTION
I enabled dbod-web on coveralls.io, I've seen that there are other settings such as installing karma-coverage and karma-coveralls. Do I make them or just adding badge is enough ?