### PR TITLE
Coverage Badge added to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/cerndb/dbod-web.svg?branch=master)](https://travis-ci.org/cerndb/dbod-web)
+[![Coverage Status](https://coveralls.io/repos/github/cerndb/dbod-web/badge.svg?branch=master)](https://coveralls.io/github/cerndb/dbod-web?branch=master)
 
 # Dbod
 


### PR DESCRIPTION
I enabled dbod-web from coveralls.io, I've seen that there are some settings with package.json and .travis.yml files but I did not make changes. Is adding badge to README file enough or do I make changes for those files ?

Closes #34 